### PR TITLE
Adding parameters to the extension

### DIFF
--- a/src/commands/runModel.ts
+++ b/src/commands/runModel.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import { window } from "vscode";
+import { workspace } from "vscode";
 import { manifestContainer } from "../manifest/manifestContainer";
 import { NodeTreeItem } from "../treeview_provider/ModelParentTreeviewProvider";
 
@@ -39,15 +40,20 @@ const runTerminal = async (modelName: string, type?: RunModelType) => {
   const projectRootpath = manifestContainer.getProjectRootpath(currentFilePath);
   
   if (modelName !== undefined && projectRootpath !== undefined) {
-    const terminal = window.createTerminal({
-      name: 'DBT',
-      cwd: projectRootpath,
-    });
+    const terminal = workspace.getConfiguration('innoverio-vscode-dbt-power-user.setting').get('current_terminal') && window.activeTerminal 
+      ? window.activeTerminal 
+      : window.createTerminal({
+        name: 'DBT',
+        cwd: projectRootpath,
+       });
     // should sleep after the terminal cration in order for the venv to be activated
     await sleep(500);
     const plusOperatorLeft = type === RunModelType.PARENTS ? '+' : '';
     const plusOperatorRight = type === RunModelType.CHILDREN ? '+' : '';
-    terminal.sendText(`dbt run --model ${plusOperatorLeft}${modelName}${plusOperatorRight}`);
+    const dbt_command =  workspace.getConfiguration('innoverio-vscode-dbt-power-user.setting').get('dbt_command') 
+      ? workspace.getConfiguration('innoverio-vscode-dbt-power-user.setting').get('dbt_command') 
+      : `dbt run`
+    terminal.sendText(dbt_command + ` --model ${plusOperatorLeft}${modelName}${plusOperatorRight}`);
     terminal.show(true);
   }
 };


### PR DESCRIPTION
Quick changes to add the ability to:

1. Run the `dbt` command in the current terminal or in a new one (to fix the last comments in https://github.com/innoverio/vscode-dbt-power-user/issues/24)
2. Modify the default `dbt run` command by potentially adding flags for example (to fix https://github.com/innoverio/vscode-dbt-power-user/issues/13)

In order to work, people will need to add entries in the `settings.json` file of their workspace:


Here is an example of values:
```
"innoverio-vscode-dbt-power-user":{
        "setting":{
            "current_terminal" : true,
            "dbt_command" : "dbt run --full-refresh"
        }
    }
```

For now, those parameters show with a message saying "Unknown Configuration Setting" and I think that changes will be required in `package.json` to remove the warning, but it is working anyway.