### PR TITLE
Update regex to allow for double digit version numbers

### DIFF
--- a/src/dbt_client/index.ts
+++ b/src/dbt_client/index.ts
@@ -23,9 +23,9 @@ export class DBTClient implements Disposable {
     new EventEmitter<DBTInstallationFoundEvent>();
   public readonly onDBTInstallationFound = this._onDBTInstallationFound.event;
   private static readonly INSTALLED_VERSION =
-    /installed.*:\s*(\d\.\d\.\d)/g;
+    /installed.*:\s*(\d{1,2}\.\d{1,2}\.\d{1,2})/g;
   private static readonly LATEST_VERSION =
-    /latest.*:\s*(\d\.\d\.\d)/g;
+    /latest.*:\s*(\d{1,2}\.\d{1,2}\.\d{1,2})/g;
   private static readonly IS_INSTALLED = /installed/g;
   private pythonPath?: string;
   private dbtInstalled?: boolean;


### PR DESCRIPTION
The extension was hanging for me on DBT version 0.21.0, so I updated the regexes to allow for double digit version numbers.