### PR TITLE
Restrict execute dbt SQl to only execute when the editor has focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
         "key": "Ctrl+Enter",
         "mac": "Cmd+Enter",
         "command": "dbtPowerUser.executeSQL",
-        "when": "editorTextFocus && resourceLangId == 'jinja-sql'"
+        "when": "editorFocus && resourceLangId == 'jinja-sql'"
       },
       {
         "key": "Ctrl+'",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
         "key": "Ctrl+Enter",
         "mac": "Cmd+Enter",
         "command": "dbtPowerUser.executeSQL",
-        "when": "resourceLangId == jinja-sql"
+        "when": "editorTextFocus && resourceLangId == 'jinja-sql'"
       },
       {
         "key": "Ctrl+'",


### PR DESCRIPTION
Made the ctrl+enter shortcut work only while in the editor