### PR TITLE
[Fixed] Adapt manifest parse to not use deprecated root_path

### DIFF
--- a/src/manifest/parsers/docParser.ts
+++ b/src/manifest/parsers/docParser.ts
@@ -8,18 +8,22 @@ import { DocMetaMap } from "../../domain";
 export class DocParser {
   constructor(private terminal: DBTTerminal) {}
 
-  createDocMetaMap(docs: any[], projectName: string): Promise<DocMetaMap> {
+  createDocMetaMap(
+    docs: any[],
+    projectName: string,
+    rootPath: string
+  ): Promise<DocMetaMap> {
     return new Promise((resolve) => {
       const docMetaMap: DocMetaMap = new Map();
       if (docs === null || docs === undefined) {
         resolve(docMetaMap);
       }
       Object.values(docs).forEach(
-        ({ package_name, name, root_path, original_file_path }) => {
+        ({ package_name, name, original_file_path }) => {
           const packageName = package_name;
           const docName =
             packageName === projectName ? name : `${packageName}.${name}`;
-          const fullPath = path.join(root_path, original_file_path);
+          const fullPath = path.join(rootPath, original_file_path);
           try {
             const docFile: string = readFileSync(fullPath).toString("utf8");
             const macroFileLines = docFile.split("\n");

--- a/src/manifest/parsers/index.ts
+++ b/src/manifest/parsers/index.ts
@@ -53,17 +53,29 @@ export class ManifestParser {
     }
 
     const { nodes, sources, macros, parent_map, child_map, docs } = manifest;
+    const { path: rootPath } = projectRoot;
 
-    const nodeMetaMapPromise = this.nodeParser.createNodeMetaMap(nodes);
+    const nodeMetaMapPromise = this.nodeParser.createNodeMetaMap(
+      nodes,
+      rootPath
+    );
     const macroMetaMapPromise = this.macroParser.createMacroMetaMap(
       projectName,
-      macros
+      macros,
+      rootPath
     );
-    const sourceMetaMapPromise = this.sourceParser.createSourceMetaMap(sources);
-    const testMetaMapPromise = this.testParser.createTestMetaMap(nodes);
+    const sourceMetaMapPromise = this.sourceParser.createSourceMetaMap(
+      sources,
+      rootPath
+    );
+    const testMetaMapPromise = this.testParser.createTestMetaMap(
+      nodes,
+      rootPath
+    );
     const docMetaMapPromise = this.docParser.createDocMetaMap(
       docs,
-      projectName
+      projectName,
+      rootPath
     );
 
     const [nodeMetaMap, macroMetaMap, sourceMetaMap, testMetaMap, docMetaMap] =

--- a/src/manifest/parsers/macroParser.ts
+++ b/src/manifest/parsers/macroParser.ts
@@ -10,7 +10,8 @@ export class MacroParser {
 
   createMacroMetaMap(
     projectName: string,
-    macros: any[]
+    macros: any[],
+    rootPath: string
   ): Promise<MacroMetaMap> {
     return new Promise((resolve) => {
       const macroMetaMap: MacroMetaMap = new Map();
@@ -18,11 +19,11 @@ export class MacroParser {
         resolve(macroMetaMap);
       }
       Object.values(macros).forEach(
-        ({ package_name, name, root_path, original_file_path }) => {
+        ({ package_name, name, original_file_path }) => {
           const packageName = package_name;
           const macroName =
             packageName === projectName ? name : `${packageName}.${name}`;
-          const fullPath = path.join(root_path, original_file_path);
+          const fullPath = path.join(rootPath, original_file_path);
           try {
             const macroFile: string = readFileSync(fullPath).toString("utf8");
             const macroFileLines = macroFile.split("\n");

--- a/src/manifest/parsers/nodeParser.ts
+++ b/src/manifest/parsers/nodeParser.ts
@@ -5,7 +5,7 @@ import { DBTProject } from "../dbtProject";
 
 @provide(NodeParser)
 export class NodeParser {
-  createNodeMetaMap(nodesMap: any[]): Promise<NodeMetaMap> {
+  createNodeMetaMap(nodesMap: any[], rootPath: string): Promise<NodeMetaMap> {
     return new Promise((resolve) => {
       const modelMetaMap: NodeMetaMap = new Map();
       if (nodesMap === null || nodesMap === undefined) {
@@ -21,14 +21,13 @@ export class NodeParser {
         .forEach(
           ({
             name,
-            root_path,
             original_file_path,
             database,
             schema,
             alias,
             package_name,
           }) => {
-            const fullPath = path.join(root_path, original_file_path);
+            const fullPath = path.join(rootPath, original_file_path);
             modelMetaMap.set(name, {
               path: fullPath,
               database,

--- a/src/manifest/parsers/sourceParser.ts
+++ b/src/manifest/parsers/sourceParser.ts
@@ -8,7 +8,10 @@ import { DBTProject } from "../dbtProject";
 export class SourceParser {
   constructor(private terminal: DBTTerminal) {}
 
-  createSourceMetaMap(sourcesMap: any[]): Promise<SourceMetaMap> {
+  createSourceMetaMap(
+    sourcesMap: any[],
+    rootPath: string
+  ): Promise<SourceMetaMap> {
     return new Promise((resolve) => {
       const sourceMetaMap: SourceMetaMap = new Map();
       if (sourcesMap === null || sourcesMap === undefined) {
@@ -21,14 +24,14 @@ export class SourceParser {
         .reduce(
           (
             previousValue: SourceMetaMap,
-            { source_name, name, root_path, original_file_path }
+            { source_name, name, original_file_path }
           ) => {
             let source = previousValue.get(source_name);
             if (!source) {
               source = { tables: [] };
               previousValue.set(source_name, source);
             }
-            const fullPath = path.join(root_path, original_file_path);
+            const fullPath = path.join(rootPath, original_file_path);
             source.tables.push({ name, path: fullPath });
             return previousValue;
           },

--- a/src/manifest/parsers/testParser.ts
+++ b/src/manifest/parsers/testParser.ts
@@ -5,7 +5,7 @@ import { DBTProject } from "../dbtProject";
 
 @provide(TestParser)
 export class TestParser {
-  createTestMetaMap(testsMap: any[]): Promise<TestMetaMap> {
+  createTestMetaMap(testsMap: any[], rootPath: string): Promise<TestMetaMap> {
     return new Promise((resolve) => {
       const testMetaMap: TestMetaMap = new Map();
       if (testsMap === null || testsMap === undefined) {
@@ -17,14 +17,13 @@ export class TestParser {
           ({
             name,
             raw_sql,
-            root_path,
             original_file_path,
             database,
             schema,
             alias,
             column_name,
           }) => {
-            const fullPath = path.join(root_path, original_file_path);
+            const fullPath = path.join(rootPath, original_file_path);
             testMetaMap.set(name, {
               path: fullPath,
               raw_sql,


### PR DESCRIPTION
## Overview
After the update of DBT Core to 1.4.0 there is a change that affects the parsing of the manifest, the property of the nodes called `root_path` [is not existing anymore](https://docs.getdbt.com/guides/migration/versions/upgrading-to-v1.4)

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
