### PR TITLE
Surround source model columns with double quotes

### DIFF
--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -374,7 +374,7 @@ export class DBTProject implements Disposable {
 ),
 renamed as (
     select
-        ${columnsInRelation.map((column) => "\"" + column.column + "\"").join(",\n        ")}
+        ${columnsInRelation.map((column) => `"${column.column}"`).join(",\n        ")}
 
     from source
 )

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -374,7 +374,7 @@ export class DBTProject implements Disposable {
 ),
 renamed as (
     select
-        ${columnsInRelation.map((column) => `"${column.column}"`).join(",\n        ")}
+        ${columnsInRelation.map((column) => `{{ adapter.quote("${column.column}") }}`).join(",\n        ")}
 
     from source
 )

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -374,7 +374,7 @@ export class DBTProject implements Disposable {
 ),
 renamed as (
     select
-        ${columnsInRelation.map((column) => column.column).join(",\n        ")}
+        ${columnsInRelation.map((column) => "\"" + column.column + "\"").join(",\n        ")}
 
     from source
 )


### PR DESCRIPTION
## Overview
When generating source models, if the columns contain weird characters like `'`, the model cannot be run.
Surrounding the column names with double quotes resolves this issue.

I have no clue how vscode plugins work, so I didn't run this code yet. Please review carefully.

<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234
-->

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
