### PR TITLE
Reflect replace edits as delete & insert

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -4,7 +4,6 @@ import {
   DocumentFormattingEditProvider,
   FormattingOptions,
   ProviderResult,
-  Range,
   TextDocument,
   TextEdit,
   window,
@@ -73,12 +72,20 @@ export class DbtDocumentFormattingEditProvider
             );
           }
           if (this.isNormalChange(change)) {
-            TextEdit.replace(
-              new Range(
-                document.lineAt(change.ln1 - 1).range.start,
-                document.lineAt(change.ln2).rangeIncludingLineBreak.end
-              ),
-              change.content.slice(1)
+            // Reflect "replace" edits as delete & insert
+            // First, delete line
+            textEdits.push(
+              TextEdit.delete(
+                document.lineAt(change.ln1 - 1).rangeIncludingLineBreak
+              )
+            );
+
+            // Add line
+            textEdits.push(
+              TextEdit.insert(
+                document.lineAt(change.ln2 - 1).range.start,
+                change.content.slice(1) + "\n"
+              )
             );
           }
           if (this.isDeleteChange(change)) {


### PR DESCRIPTION
## Overview
 This resolves the [discussion](https://github.com/innoverio/vscode-dbt-power-user/discussions/315#discussioncomment-4918534)

The suggested change is:

Reflecting normal (replace) changes with a _**delete line first and then insert**_ approach rather than using vscode's `TextEdit.replace()` since the weird behavior on formatting seems because of the replace changes. I don't have experience on vscode's API. So, this the only change that I can suggest right now. Any contribution is much appreciated.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
