### PR TITLE
Subsitute variables in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "version": "0.11.4",
   "engines": {
-    "vscode": "^1.74.0"
+    "vscode": "^1.75.1"
   },
   "categories": [
     "Other"


### PR DESCRIPTION
## Overview

Expand `${workspaceFolder}` and `${env:VARIABLE}` placeholders in the settings for `dbt.profilesDirOverride` and `dbtPythonPathOverride` using the logic previously only used for environment variable settings. This address #237 and #199.

As was discussed in those issues, variable substitution is a common issue with vscode extensions and the recommended workaround was to use paths relative to the workspace directory. But with version 0.11.4 installed from the vscode marketplace, this did not work for me anymore - only absolute paths worked.

Merging this feature would be a great help for Meltano integration because settings.json can then be added to the repository, ensuring a consistent experience for all developers (see https://github.com/meltano/meltano/issues/2811)

## Checklist

- [X] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change

## Notes
- had to bump engine version due to complaint by `vsce package`
- thank you for this great extension, it makes working with dbt a real pleasure!