### PR TITLE
Skip faulty delete change for no newline at EOF

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -114,6 +114,12 @@ export class DbtDocumentFormattingEditProvider
   private isDeleteChange(
     change: parseDiff.Change
   ): change is parseDiff.DeleteChange {
-    return change.type === "del";
+    return (
+      /*  
+          parseDiff reads sqlfmt's "\ No newline at end of file" diff output as a delete change. 
+          This deceptive delete change should be skipped. So, adding an edge case to the expression.
+      */
+      change.type === "del" && change.content !== "\\ No newline at end of file"
+    );
   }
 }


### PR DESCRIPTION
## Overview

`parseDiff` reads sqlfmt's `\ No newline at end of file` diff output as a delete change. So, this deceptive delete change should be skipped. I attempted to handle this by adding an edge case to the expression. A sample `changes` list from `parseDiff` below:

```typescript
changes: [
  // ...
  {
    type: "del",
    del: true,
    ln: 33,
    content: "-where json:EventCode is not null"
  },
  {
    type: "del",
    del: true,
    ln1: undefined,
    ln2: undefined,
    ln: 33,
    content: "\\ No newline at end of file"
  }
  // ...
]
```
