### PR TITLE
Option to skip re-parsing the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
             "default": [],
             "description": "Add additional params to the dbt build model command."
           },
+          "dbt.skipParsing": {
+            "type": "boolean",
+            "description": "Option to skip re-parsing the project in the background."
+          },
           "dbt.profilesDirOverride": {
             "type": "string",
             "description": "Override the profiles dir for every dbt command. Absolute path or relative to the directory containing profiles.yml"

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -270,6 +270,17 @@ export class DBTProject implements Disposable {
   }
 
   private async rebuildManifest() {
+    const skipParsing = workspace
+      .getConfiguration("dbt")
+      .get<boolean>(
+        "skipParsing",
+        false,
+      );
+    if (skipParsing) {
+      console.log("opting out of rebuilding the manifest");
+      return;
+    }
+
     if (!this.pythonBridgeInitialized) {
       window.showErrorMessage(
         "The dbt manifest can't be rebuilt right now as the Python environment has not yet been initialized, please try again later.",


### PR DESCRIPTION
## Overview
We don't allow for users to hardcode the data warehouse credentials so we are using the vscode settings to set the env variables to empty strings:
```
  "terminal.integrated.env.linux": {
    "SNOWFLAKE_ACCOUNT": "",
    "SNOWFLAKE_WAREHOUSE": "",
    "SNOWFLAKE_PASSWORD": "",
```
We still get all the benefit of the features that don't require the data warehouse connection but the empty strings are causing our `dbt` commands to trigger a full parse.

We need some way to skip the regenerating of the manifest. We are satisfied with users doing that on their own manually from the command line.

This is more of a proposal than a PR. I haven't taken the time yet to figure out how to test this out.

## Checklist

- [ ] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
