### PR TITLE
Add the `targetPathOverride` config value

### DIFF
--- a/dbt_integration.py
+++ b/dbt_integration.py
@@ -145,7 +145,8 @@ class ConfigInterface:
         target: Optional[str] = None,
         profiles_dir: Optional[str] = None,
         project_dir: Optional[str] = None,
-        profile: Optional[str] = None
+        profile: Optional[str] = None,
+        target_path: Optional[str] = None,
     ):
         self.threads = threads
         self.target = target
@@ -155,6 +156,7 @@ class ConfigInterface:
         self.single_threaded = threads == 1
         self.quiet = True
         self.profile = profile
+        self.target_path = target_path
 
 
 class ManifestProxy(UserDict):
@@ -205,6 +207,7 @@ class DbtProject:
         project_dir: Optional[str] = None,
         threads: Optional[int] = 1,
         profile: Optional[str] = None,
+        target_path: Optional[str] = None,
     ):
         
         self.args = ConfigInterface(
@@ -213,6 +216,7 @@ class DbtProject:
             profiles_dir=profiles_dir,
             project_dir=project_dir,
             profile=profile,
+            target_path = target_path,
         )
 
         self.init_project()

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
           },
           "dbt.targetPathOverride": {
             "type": "string",
-            "description": "Override the target-path value for dbt processes run by the extension."
+            "description": "Override the target-path dir for every dbt command. Absolute path or relative to the directory containing manifest.json."
           },
           "dbt.queryLimit": {
             "type": "integer",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
             "type": "string",
             "description": "Override the profiles dir for every dbt command. Absolute path or relative to the directory containing profiles.yml"
           },
+          "dbt.targetPathOverride": {
+            "type": "string",
+            "description": "Override the target-path value for dbt processes run by the extension."
+          },
           "dbt.queryLimit": {
             "type": "integer",
             "description": "The maximum number of rows the `Preview SQL Query` command returns.",

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -643,13 +643,17 @@ select * from renamed
     const targetPathOverride = workspace
       .getConfiguration("dbt")
       .get<string>("targetPathOverride");
-    if (targetPathOverride !== undefined) {
-      return substituteSettingsVariables(targetPathOverride);
-    }
-    if (projectConfig[DBTProject.TARGET_PATH_VAR] !== undefined) {
-      return projectConfig[DBTProject.TARGET_PATH_VAR] as string;
-    }
-    return "target";
+
+    return (
+      (targetPathOverride
+        ? substituteSettingsVariables(targetPathOverride)
+        : false) ||
+      process.env.DBT_TARGET_PATH ||
+      (projectConfig[DBTProject.TARGET_PATH_VAR]
+        ? (projectConfig[DBTProject.TARGET_PATH_VAR] as string)
+        : false) ||
+      "target"
+    );
   }
 
   private async refresh() {

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -123,6 +123,7 @@ export class DBTProject implements Disposable {
     console.log("Using profile directory " + this.dbtProfilesDir);
     this.projectName = projectConfig.name;
     this.targetPath = this.findTargetPath(projectConfig);
+    console.log("Using target path " + this.targetPath);
     this.sourcePaths = this.findSourcePaths(projectConfig);
     this.macroPaths = this.findMacroPaths(projectConfig);
 
@@ -203,7 +204,7 @@ export class DBTProject implements Disposable {
     try {
       await this.python.ex`from dbt_integration import *`;
       await this.python
-        .ex`project = DbtProject(project_dir=${this.projectRoot.fsPath}, profiles_dir=${this.dbtProfilesDir})`;
+        .ex`project = DbtProject(project_dir=${this.projectRoot.fsPath}, profiles_dir=${this.dbtProfilesDir}, target_path=${this.targetPath})`;
       // now we can accept project method invocations on the python env.
       this.pythonBridgeInitialized = true;
     } catch (exc: any) {
@@ -639,6 +640,12 @@ select * from renamed
   }
 
   private findTargetPath(projectConfig: any): string {
+    const targetPathOverride = workspace
+      .getConfiguration("dbt")
+      .get<string>("targetPathOverride");
+    if (targetPathOverride !== undefined) {
+      return substituteSettingsVariables(targetPathOverride);
+    }
     if (projectConfig[DBTProject.TARGET_PATH_VAR] !== undefined) {
       return projectConfig[DBTProject.TARGET_PATH_VAR] as string;
     }

--- a/src/manifest/dbtProject.ts
+++ b/src/manifest/dbtProject.ts
@@ -648,7 +648,7 @@ select * from renamed
       (targetPathOverride
         ? substituteSettingsVariables(targetPathOverride)
         : false) ||
-      process.env.DBT_TARGET_PATH ||
+      this.PythonEnvironment.environmentVariables.DBT_TARGET_PATH ||
       (projectConfig[DBTProject.TARGET_PATH_VAR]
         ? (projectConfig[DBTProject.TARGET_PATH_VAR] as string)
         : false) ||

--- a/src/manifest/parsers/index.ts
+++ b/src/manifest/parsers/index.ts
@@ -114,14 +114,9 @@ export class ManifestParser {
   }
 
   private readAndParseManifest(projectRoot: Uri, targetPath: string) {
-    let manifestLocation = path.join(
-      projectRoot.fsPath,
-      targetPath,
-      DBTProject.MANIFEST_FILE,
-    );
-    // Check to see if the target path includes the project root already
-    if (targetPath.startsWith(projectRoot.fsPath)) {
-      manifestLocation = path.join(targetPath, DBTProject.MANIFEST_FILE);
+    let manifestLocation = path.join(targetPath, DBTProject.MANIFEST_FILE);
+    if (!path.isAbsolute(targetPath)) {
+      manifestLocation = path.join(projectRoot.fsPath, manifestLocation);
     }
 
     try {

--- a/src/manifest/parsers/index.ts
+++ b/src/manifest/parsers/index.ts
@@ -114,11 +114,16 @@ export class ManifestParser {
   }
 
   private readAndParseManifest(projectRoot: Uri, targetPath: string) {
-    const manifestLocation = path.join(
+    let manifestLocation = path.join(
       projectRoot.fsPath,
       targetPath,
       DBTProject.MANIFEST_FILE,
     );
+    // Check to see if the target path includes the project root already
+    if (targetPath.startsWith(projectRoot.fsPath)) {
+      manifestLocation = path.join(targetPath, DBTProject.MANIFEST_FILE);
+    }
+
     try {
       const manifestFile = readFileSync(manifestLocation, "utf8");
       return JSON.parse(manifestFile);

--- a/src/manifest/parsers/index.ts
+++ b/src/manifest/parsers/index.ts
@@ -114,10 +114,11 @@ export class ManifestParser {
   }
 
   private readAndParseManifest(projectRoot: Uri, targetPath: string) {
-    let manifestLocation = path.join(targetPath, DBTProject.MANIFEST_FILE);
+    const pathParts = [targetPath];
     if (!path.isAbsolute(targetPath)) {
-      manifestLocation = path.join(projectRoot.fsPath, manifestLocation);
+      pathParts.unshift(projectRoot.fsPath);
     }
+    const manifestLocation = path.join(...pathParts, DBTProject.MANIFEST_FILE);
 
     try {
       const manifestFile = readFileSync(manifestLocation, "utf8");


### PR DESCRIPTION
## Overview
    
resolves #444 

Creates a new configuration option for overriding the target path. This should help for folks that have Jinja in their dbt_project file `target-path` value and for situations where you want a separate manifest that the extension manages vs the manifest you use for development.

I tested this against the dbt `jaffle_shop` demo repo. If you set the path to `"dbt.targetPathOverride": "${workspaceFolder}/target_2",` the extension will read and write to the `target_2` dir. Confirmed in the debug output that `Using target path /Users/jasonb/code/jaffle_shop/target_2` showed up.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
