### PR TITLE
Fix bug for empty sqlFmtAdditionalParams

### DIFF
--- a/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
+++ b/src/document_formatting_edit_provider/dbtDocumentFormattingEditProvider.ts
@@ -39,7 +39,8 @@ export class DbtDocumentFormattingEditProvider
       .getConfiguration("dbt")
       .get<string[]>("sqlFmtAdditionalParams", [])
       .join(" ")
-      .split(" ");
+      .split(" ")
+      .filter((s) => s !== "");
 
     const sqlFmtArgs = [
       "--diff",


### PR DESCRIPTION
## Overview
<!---
  Include the number of the issue addressed by this PR above if applicable.

  Example:
    resolves #1234
-->

In the previous code, an empty string (`[""]`) is passed as `sqlFmtAdditionalParamsSetting` when `sqlFmtAdditionalParams` has no settings.

This causes sqlfmt to stop working in my environment.

According to https://docs.sqlfmt.com/getting-started/configuring-sqlfmt#configuration-reference, an empty string is never passed as an option in sqlfmt. So, empty strings should not be included in `sqlFmtAdditionalParamsSetting`.


I have not been able to determine why sqlfmt was not working when an empty string was passed. My apologies for this.

## Checklist

- [x] I have run this code and it appears to resolve the stated issue
- [ ] `README.md` updated and added information about my change
